### PR TITLE
actions: only push image on branch push, not on PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             GH_VERSION=${{ env.GH_VERSION }}


### PR DESCRIPTION
Set `push: false` for PR events so that pull requests only trigger a build (for CI verification) without pushing an image to GHCR. Pushes only happen on direct branch pushes to main/master.