### PR TITLE
actions: fix smoke-test docker pull to use only first tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           echo "Available tags:"
           docker images ghcr.io/${{ github.repository }}
           echo "Pulling: ${{ needs.build.outputs.image-tag }}"
-          docker pull ${{ needs.build.outputs.image-tag }}
+          echo "${{ needs.build.outputs.image-tag }}" | head -1 | xargs docker pull
 
       - name: Start container (override entrypoint to skip startup)
         run: |


### PR DESCRIPTION
The `image-tag` output contains two tags (e.g. `ghcr.io/...:sha-xxx` and `ghcr.io/...:latest`) on separate lines. Interpolating it directly into `docker pull` treats the second line as a separate command, causing `No such file` errors. This fixes it by piping through `head -1 | xargs docker pull`.