### PR TITLE
fix: extract single tag for docker run in smoke-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,11 +94,12 @@ jobs:
 
       - name: Start container (override entrypoint to skip startup)
         run: |
+          IMAGE_TAG=$(echo "${{ needs.build.outputs.image-tag }}" | head -1)
           docker run -d --rm \
             --name smoke-test \
             --privileged \
             -e TAILSCALE_AUTH_KEY=*** \
-            ${{ needs.build.outputs.image-tag }} \
+            $IMAGE_TAG \
             tail -f /dev/null
 
       - name: Wait for startup


### PR DESCRIPTION
The smoke-test was failing because `image-tag` outputs two lines (latest + sha-xxx). The `docker run` command on line 101 used the raw output directly, causing the second line to be interpreted as a separate shell command. Fixed by extracting only the first line into a variable before passing to `docker run`.